### PR TITLE
Fix: Corrected responsive styling and path for flag image

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,14 +411,14 @@
             
             .icon-20 img {
                 width: 20px;
-                height: px;
+                height: 20px;
             }
         }
  </style>
   <div class="true">
         <div class="line-center">
             <div class="inc-icon icon-20">
-                <img src="/images/vn_flag.svg" alt="Vietnam">
+                <img src="images/vn_flag.svg" alt="Vietnam">
             </div>
             <span>Hoàng Sa & Trường Sa là của Việt Nam!</span>
         </div>


### PR DESCRIPTION
This commit addresses two issues:
1. A CSS typo where the image height was set to an invalid 'px' value within a media query for mobile devices. This has been corrected to '20px'.
2. The image source path was absolute ('/images/vn_flag.svg'), which caused it to break when viewed as a local file. The path has been updated to be relative ('images/vn_flag.svg').

These changes ensure the flag icon in the 'Hoàng Sa & Trường Sa' banner displays correctly and at the proper size on mobile devices.